### PR TITLE
Fix non-string waveform data after parsing is always zero

### DIFF
--- a/aaclient/pb.h
+++ b/aaclient/pb.h
@@ -121,6 +121,8 @@ template<typename E>
 typename std::enable_if<std::is_pod<E>::value>::type
 val_assign(const google::protobuf::RepeatedField<E>& v, char *& cur, size_t maxelems)
 {
+    size_t l = v.size();
+    memcpy(cur, v.data(), sizeof(E)*l);
     cur += sizeof(E)*maxelems;
 }
 


### PR DESCRIPTION
For non-string waveform data, it seems that even if the waveform data retrieved from Archiver Appliance is valid, the waveform elements parsed and returned in `raw_iter()` method are always zero. This PR is trying to fix it. 