### PR TITLE
Fix aaget only prints first element for waveform

### DIFF
--- a/aaclient/cmd/get.py
+++ b/aaclient/cmd/get.py
@@ -79,7 +79,7 @@ async def getnprint(args, arch, pv, printName=True):
             if sevr:
                 out += [_sevr.get(sevr) or str(sevr), str(M['status'])]
 
-            if V.size!=1: # scalar, print alarm before value
+            if V.size!=1: # array/waveform, print alarm before value
                 out.append(repr(V))
 
             print(' '.join(out))

--- a/aaclient/cmd/get.py
+++ b/aaclient/cmd/get.py
@@ -72,14 +72,14 @@ async def getnprint(args, arch, pv, printName=True):
             if printName:
                 out.append(pv)
 
-            if len(V.shape)==1: # scalar, print alarm after value
+            if V.size==1: # scalar, print alarm after value
                 out.append(str(V[0]))
 
             sevr = M['severity']
             if sevr:
                 out += [_sevr.get(sevr) or str(sevr), str(M['status'])]
 
-            if len(V.shape)!=1: # scalar, print alarm before value
+            if V.size!=1: # scalar, print alarm before value
                 out.append(repr(V))
 
             print(' '.join(out))


### PR DESCRIPTION
In `printpv()` method in `get.py` module, it seems that `len(V.shape)` is always 1 after ` V, M = val[i,:], meta[i]` statement, no matter value is scalar or array, so `aaget` only prints the first element of the waveform as follows,

<img width="1354" height="237" alt="image" src="https://github.com/user-attachments/assets/8329fe52-ae7e-43b0-af6c-8e9db1a85102" />

With this PR, it seems that `aaget` can print full waveform as follows,

<img width="1351" height="669" alt="image" src="https://github.com/user-attachments/assets/cdefa57f-f0ce-4219-9e3c-9f53ec518622" />

This PR also fixes a typo in the comment for array/waveform value.

