### PR TITLE
Fix aah5 raise attribute error for large data

### DIFF
--- a/aaclient/cmd/h5.py
+++ b/aaclient/cmd/h5.py
@@ -64,14 +64,14 @@ async def getnprint(args, arch, pv, grp):
 
             check_type = V.dtype
 
-        elif check_type.dtype!=V.dtype:
-            ok = check_type.dtype.kind  in ('i','f') and V.dtype.kind in ('i', 'f')
-            check_type = V.dtype
+        elif check_type!=V.dtype:
+            ok = check_type.kind  in ('i','f') and V.dtype.kind in ('i', 'f')
             if ok:
                 _log.warn('Type change %r -> %r.  Using implicit cast', check_type, V.dtype)
             else:
                 _log.error('Type change %r -> %r not supported.  Dropping samples.', check_type, V.dtype)
                 continue
+            check_type = V.dtype
 
         mstart = Ms.shape[0]
         Vs.resize((mstart+V.shape[0], max(Vs.shape[1], V.shape[1])))


### PR DESCRIPTION
In `getnprint()` method in `h5.py` module, it seems that after `check_type = V.dtype` statement, `check_type` itself is `dtype` and does not have `dtype` attribute. Therefore, when data sample is larger than the default chunkSize and code enters the second iteration with the returned value of `raw_iter()`, `elif check_type.dtype!=V.dtype:` statement raises attribute error as follows. This PR is trying to fix it. 

<img width="1437" height="912" alt="image" src="https://github.com/user-attachments/assets/67f8f1fd-2832-4d41-b768-628d98c0906b" />

This PR also moves `check_type = V.dtype` after the logging statement to prevent the `check_type` variable from being overwritten  like this.

<img width="1437" height="175" alt="image" src="https://github.com/user-attachments/assets/ae847de4-bdf1-4f02-a5bf-0e8d2be92593" />
