### PR TITLE
Fix aagrep only retrieves 500 PV names at most

### DIFF
--- a/aaclient/appl.py
+++ b/aaclient/appl.py
@@ -77,7 +77,8 @@ class Appl(IArchive):
 
         _log.debug("searching for %r", pattern)
 
-        pvs = await (await self.__get(self._info['mgmtURL']+'/getAllPVs', params={'regex':pattern})).json()
+        # Fetch all PVs matching the regex; limit=-1 means no limit (otherwise defaults to 500)
+        pvs = await (await self.__get(self._info['mgmtURL']+'/getAllPVs', params={'regex':pattern,'limit':-1})).json()
 
         if opM is not None:
             pvs = [f'{opM.group(1)}({pv})' for pv in pvs]


### PR DESCRIPTION
It seems that `aagrep` can only retrieve 500 PV names at most according to the following link,
https://github.com/archiver-appliance/epicsarchiverap/blob/master/src/main/org/epics/archiverappliance/mgmt/bpl/GetAllPVs.java

This PR adds the `limit=-1` query parameter in order to prevent the 500 limitation.