### PR TITLE
Fix argparse default match mode

### DIFF
--- a/aaclient/util.py
+++ b/aaclient/util.py
@@ -146,11 +146,10 @@ def add_common_args(P):
                    help='Make more noise')
 
 def add_search_args(G):
+    G.set_defaults(match=MatchMode.Regex)
     G.add_argument('-W', '--wildcard', action='store_const', dest='match', const=MatchMode.Wildcard,
-                   default=MatchMode.Wildcard,
                    help='Match names as wildcard patterns')
     G.add_argument('-R', '--regexp', action='store_const', dest='match', const=MatchMode.Regex,
-                   default=MatchMode.Regex,
                    help='Match names as regular expressions  (default)')
     G.add_argument('--exact', action='store_const', dest='match', const=MatchMode.Exact,
                    help='Match names exactly')


### PR DESCRIPTION
The help message of `aagrep` shows that `Regex` is the default match mode. However, both `-W` and `-R` have the `default` attribute, and on my Python 3.11.2 environment, it seems that the actual default match mode is `Wildcard` as follows,

<img width="1274" height="382" alt="image" src="https://github.com/user-attachments/assets/4d8b3d16-194f-464b-b14e-9f05fb46ecfd" />

Trying to remove `default=MatchMode.Wildcard` did not work and raised the following error,
```
File "/home/control/PR/aaclient/aaclient/appl.py", line 52, in search
    assert match in MatchMode, match
           ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/enum.py", line 745, in __contains__
    raise TypeError(
TypeError: unsupported operand type(s) for 'in': 'NoneType' and 'EnumType'
```

Finally, AI suggested me to remove the `default=` attribute and use  `set_defaults()` instead, which is exactly what this PR contains.
`G.set_defaults(match=MatchMode.Regex)`



  