### PR TITLE
Fix SHORT and ENUM data types

### DIFF
--- a/aaclient/ext.pyx
+++ b/aaclient/ext.pyx
@@ -227,7 +227,7 @@ def encode_samples(ptype, list samps):
 
         elif pt==SCALAR_SHORT or pt==SCALAR_ENUM:
             i16 = V
-            if pt==SCALAR_ENUM:
+            if pt==SCALAR_SHORT:
                 encode_sample[ScalarShort](raw, &i16, 1, meta, cnxlostepsecs)
             elif pt==SCALAR_ENUM:
                 encode_sample[ScalarEnum](raw, &i16, 1, meta, cnxlostepsecs)


### PR DESCRIPTION
It seems that `EPICSEvent.proto` uses `int32` for `SHORT` and `ENUM` data type so that `val_assign(pb.val(), cur, maxelems);` in `pb.h` passes `int32` input to `val_assign()` which expects `int16` output for `SHORT` and `ENUM`, which causes crash (Segmentation fault) or data corrupt (0 in the screenshot is incorrect data) as follows,

<img width="1130" height="545" alt="27974748878e44b1342d0b6389b709a6" src="https://github.com/user-attachments/assets/f06b1f91-d1f3-4808-862e-1bc5677043d9" />

With this PR, it seems to work properly as follows,

<img width="1125" height="726" alt="cad3f3e7c034bcc30295de5f13b27ae5" src="https://github.com/user-attachments/assets/f7be1048-9c40-461d-91bd-73117512c3d6" />

This PR made the following modifications,
1. Pass `PayloadType` to `val_assign()` and handle SHORT/ENUM inside the function.
2. Fix a typo in `ext.pyx`

AI suggested me to also change data types in the following lines to `int32_t` or `i32`, but it already seems to work properly even without these modifications.

pb.h
```
PBATTR(ScalarShort, SCALAR_SHORT, int16_t, false);
PBATTR(ScalarEnum, SCALAR_ENUM, int16_t, false);
PBATTR(VectorShort, WAVEFORM_SHORT, int16_t, true);
PBATTR(VectorEnum, WAVEFORM_ENUM, int16_t, true);
```

ext.pyx
```
elif pt==SCALAR_SHORT or pt==SCALAR_ENUM:
            i16 = V
            if pt==SCALAR_ENUM:
                encode_sample[ScalarShort](raw, &i16, 1, meta, cnxlostepsecs)
            elif pt==SCALAR_ENUM:
                encode_sample[ScalarEnum](raw, &i16, 1, meta, cnxlostepsecs)

elif pt==WAVEFORM_SHORT or pt==WAVEFORM_ENUM:
            ai16.resize(len(V))
            for i,v in enumerate(V):
                ai16[i] = v
            if pt==WAVEFORM_SHORT:
                encode_sample[VectorShort](raw, ai16.data(), ai16.size(), meta, cnxlostepsecs)
            elif pt==WAVEFORM_ENUM:
                encode_sample[VectorEnum](raw, ai16.data(), ai16.size(), meta, cnxlostepsecs)
```